### PR TITLE
shiny.fluent highlighted as a default package

### DIFF
--- a/app/scripts/hexData.js
+++ b/app/scripts/hexData.js
@@ -18,10 +18,10 @@ const _A = {
 const _L = {
   logo: 'logo'
 };
-// Shiny.semantic cell
+// Shiny.fluent cell
 const _S = {
-  library: 'shiny-semantic',
-  title: 'shiny.semantic'
+  library: 'shiny-fluent',
+  title: 'shiny.fluent'
 };
 // Semantic.dashboard cell
 const _D = {
@@ -55,8 +55,8 @@ const _C = {
 };
 // Shiny.fluent
 const _F = {
-  library: 'shiny-fluent',
-  title: 'shiny.fluent'
+  library: 'shiny-semantic',
+  title: 'shiny.semantic'
 };
 // data.validator
 const _V = {

--- a/app/scripts/libraries.js
+++ b/app/scripts/libraries.js
@@ -1,5 +1,15 @@
 export const libraries = [
   {
+    'id': 'shiny-fluent',
+    'heading': 'shiny.fluent',
+    'paragraphs': [
+      'We believe that a great UI plays a huge role in the success of application projects. shiny.fluent gives your apps a beautiful and professional look, rich set of easy-to-use components in Shiny, and fast speed of development that Shiny is famous for.',
+      'As Fluent UI is built in React, shiny.fluent is based on another package called shiny.react, which allows for using React libraries in Shiny.'
+    ],
+    'repoLink': 'https://github.com/Appsilon/shiny.fluent',
+    'demoLink': 'https://demo.appsilon.com/apps/fluentui/'
+  },
+  {
     'id': 'shiny-semantic',
     'heading': 'shiny.semantic',
     'paragraphs': [
@@ -67,16 +77,6 @@ export const libraries = [
       'This R package enables using React in Shiny apps and is used by the shiny.fluent package. It contains R and JS code which is independent from the React library (e.g. Fluent UI) that is being wrapped.'
     ],
     'repoLink': 'https://github.com/Appsilon/shiny.react',
-    'demoLink': 'https://demo.appsilon.com/apps/fluentui/'
-  },
-  {
-    'id': 'shiny-fluent',
-    'heading': 'shiny.fluent',
-    'paragraphs': [
-      'We believe that a great UI plays a huge role in the success of application projects. shiny.fluent gives your apps a beautiful and professional look, rich set of easy-to-use components in Shiny, and fast speed of development that Shiny is famous for.',
-      'As Fluent UI is built in React, shiny.fluent is based on another package called shiny.react, which allows for using React libraries in Shiny.'
-    ],
-    'repoLink': 'https://github.com/Appsilon/shiny.fluent',
     'demoLink': 'https://demo.appsilon.com/apps/fluentui/'
   },
   {

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -45,7 +45,7 @@ const getCell = (cell) => {
     cell__blank
     ${library ? 'cell__blank--library' : ''}
     ${library ? `cell__blank--${library}` : ''}
-    ${library === 'shiny-semantic' ? 'cell__blank--shiny-semantic active' : ''}
+    ${library === 'shiny-fluent' ? 'cell__blank--shiny-fluent active' : ''}
     ${logo ? `cell__blank--${logo}` : ''}
     ${level ? 'cell__blank--detached' : 'cell__blank--attached'}
     ${level ? `cell__blank--${level}` : ''}


### PR DESCRIPTION
Now the landing page will look like this as a default view:

![FireShot Capture 1515 - shiny tools - localhost](https://user-images.githubusercontent.com/4669074/143139053-75f9092b-865e-438d-9034-d293cd94cedd.jpg)


