### PR TITLE
Update libraries.js

### DIFF
--- a/app/scripts/libraries.js
+++ b/app/scripts/libraries.js
@@ -7,7 +7,7 @@ export const libraries = [
       'As Fluent UI is built in React, shiny.fluent is based on another package called shiny.react, which allows for using React libraries in Shiny.'
     ],
     'repoLink': 'https://github.com/Appsilon/shiny.fluent',
-    'demoLink': 'https://demo.appsilon.com/apps/fluentui/'
+    'demoLink': 'https://connect.appsilon.com/fluentui/'
   },
   {
     'id': 'shiny-semantic',
@@ -17,7 +17,7 @@ export const libraries = [
       'With this library it is easy to wrap Shiny with Fomantic (previously Semantic). Add a few simple lines of code to give your UI a fresh, modern and highly interactive look.'
     ],
     'repoLink': 'https://github.com/Appsilon/shiny.semantic',
-    'demoLink': 'https://demo.appsilon.ai/apps/visuarisk/'
+    'demoLink': 'https://connect.appsilon.com/polluter-alert/'
   },
   {
     'id': 'semantic-dashboard',
@@ -27,7 +27,7 @@ export const libraries = [
       'Are you fed up with ordinary shinydashboard look? Give your app a new life with Semantic UI support. It cannot be any easier! Just install semantic.dashboard and load it instead to your app. Thanks to the compatibility with classical dashboard you don\'t have to start from scratch.'
     ],
     'repoLink': 'https://github.com/Appsilon/semantic.dashboard',
-    'demoLink': 'https://appsilon.github.io/semantic.dashboard/'
+    'demoLink': 'https://connect.appsilon.com/Deer-Observations-Explorer/'
   },
   {
     'id': 'shiny-worker',
@@ -37,7 +37,7 @@ export const libraries = [
       'Shiny.worker allows you to delegate heavy computation tasks to a separate process, such that it does not freeze your Shiny app.'
     ],
     'repoLink': 'https://github.com/Appsilon/shiny.worker',
-    'demoLink': 'https://demo.appsilon.ai/apps/shiny-worker/'
+    'demoLink': 'https://connect.appsilon.com/shiny-worker/'
   },
   {
     'id': 'shiny-info',
@@ -47,7 +47,7 @@ export const libraries = [
       'Display simple information of the shiny project in the user interface of the app.'
     ],
     'repoLink': 'https://github.com/Appsilon/shiny.info',
-    'demoLink': 'https://demo.appsilon.ai/apps/shiny_info_demo/'
+    'demoLink': 'https://connect.appsilon.com/shiny_info_demo/'
   },
   {
     'id': 'shiny-router',
@@ -57,7 +57,7 @@ export const libraries = [
       'A minimalistic router for your Shiny apps.'
     ],
     'repoLink': 'https://github.com/Appsilon/shiny.router',
-    'demoLink': 'https://demo.appsilon.ai/apps/router2/'
+    'demoLink': 'https://connect.appsilon.com/router/'
   },
   {
     'id': 'shiny-i18n',
@@ -67,7 +67,7 @@ export const libraries = [
       'Using it is very simple: just prepare your translation files in one of the supported formats, read them into your app using user-friendly shiny.i18n interface and surround your expressions to translate by a translator tag. Thanks to that your app will remain neat and readible.'
     ],
     'repoLink': 'https://github.com/Appsilon/shiny.i18n',
-    'demoLink': 'https://appsilon.github.io/shiny.i18n/'
+    'demoLink': 'https://connect.appsilon.com/i18n/'
   },
   {
     'id': 'shiny-react',
@@ -77,7 +77,7 @@ export const libraries = [
       'This R package enables using React in Shiny apps and is used by the shiny.fluent package. It contains R and JS code which is independent from the React library (e.g. Fluent UI) that is being wrapped.'
     ],
     'repoLink': 'https://github.com/Appsilon/shiny.react',
-    'demoLink': 'https://demo.appsilon.com/apps/fluentui/'
+    'demoLink': 'https://connect.appsilon.com/fluentui/'
   },
   {
     'id': 'data-validator',
@@ -87,6 +87,6 @@ export const libraries = [
       'It provides functions for validating datasets in %>% pipelines (validate_if, validate_cols and validate_rows), predicate functions from assertr package (like in_set, within_bounds, etc.) and functions for creating user-friendly reports that you can send to email, store in logs folder, or generate automatically with RStudio Connect.'
     ],
     'repoLink': 'https://github.com/Appsilon/data.validator',
-    'demoLink': 'https://appsilon.github.io/data.validator/'
+    'demoLink': 'https://connect.prod.aws.appsilon.com/connect_validation_workflow/connect_workflow.html'
   }
 ]


### PR DESCRIPTION
Updated demoLinks for:
- shiny.fluent
- shiny.router
- shiny.i18n
- data.validator
- shiny.react
- shiny.semantic
- semantic.dashboard
- shiny.worker
- shiny.info

## Changes description
Old demo links for https://demo.appsilon.ai/.. were redirecting to deadlinks: legacy.appsilon.com 
Exceptions that were also changed: semantic.dashboard, shiny.i18n, and data.validator were sent to incorrect github pages. 

Packages and demo URLs confirmed by Kuba Nowicki may be found here: https://docs.google.com/spreadsheets/d/1hMLItpHSPNcysMbYhzREWytMtbgDKxVUr8i9fDjQPno/edit#gid=0